### PR TITLE
Fix bug with `input_file_size` using `/dev/sdb` instead of `input_file`

### DIFF
--- a/benchmark-file-region-speed
+++ b/benchmark-file-region-speed
@@ -1,7 +1,7 @@
 #!/bin/sh
 input_file="$1"
 block_size="$(expr 256 '*' 1024 '*' 1024)"
-input_file_size="$(lsblk -n -d -b -o SIZE '/dev/sdb')"
+input_file_size="$(lsblk -n -d -b -o SIZE ${input_file})"
 range_size="$(expr ${input_file_size} '/' 127)"
 block_count="$(expr ${range_size} '/' ${block_size})"
 current_block=0


### PR DESCRIPTION
Seems to be a minor oversight. Fixed it.